### PR TITLE
Logging and Fonz UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project specifics
 logs.txt
+logs/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Project specifics
+logs.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/fonz/cli.py
+++ b/fonz/cli.py
@@ -33,7 +33,7 @@ def sql(url, client_id, client_secret, port, api, project, branch):
     explores = client.get_explores()
     explores = client.get_dimensions(explores)
     validate = client.validate_explores(explores)
-    client.print_results(validate)
+    client.handle_errors(validate)
 
 
 cli.add_command(connect)

--- a/fonz/cli.py
+++ b/fonz/cli.py
@@ -24,10 +24,13 @@ def connect(url, client_id, client_secret, port, api):
 @click.argument('url', envvar='LOOKER_BASE_URL')
 @click.argument('client_id', envvar='LOOKER_CLIENT_ID')
 @click.argument('client_secret', envvar='LOOKER_CLIENT_SECRET')
+@click.option('--model', default=None)
 @click.option('--port', default=19999)
 @click.option('--api', default='3.0')
-def sql(url, client_id, client_secret, port, api, project, branch):
-    client = Fonz(url, client_id, client_secret, port, api, project, branch)
+def sql(url, client_id, client_secret, port, api, model, project, branch):
+    client = Fonz(
+        url, client_id, client_secret,
+        port, api, model, project, branch)
     client.connect()
     client.update_session()
     explores = client.get_explores()

--- a/fonz/connection.py
+++ b/fonz/connection.py
@@ -167,14 +167,14 @@ class Fonz:
                 print_pass(explore, index, total)
 
             elif 'looker_error' in query_result[0]:
-                logging.info('Error in explore {}: {}'.format(
+                logger.debug('Error in explore {}: {}'.format(
                     explore['explore'],
                     query_result[0]['looker_error'])
                 )
                 explore['failed'] = True
                 explore['error'] = query_result[0]['looker_error']
                 print_fail(explore, index, total)
-                
+
             else:
                 explore['failed'] = False
                 print_pass(explore, index, total)

--- a/fonz/connection.py
+++ b/fonz/connection.py
@@ -13,7 +13,8 @@ JsonDict = Dict[str, Any]
 class Fonz:
 
     def __init__(self, url: str, client_id: str, client_secret: str,
-                 port: int, api: str, project: str = None, branch: str = None):
+                 port: int, api: str, model: Optional[str] = None,
+                 project: str = None, branch: str = None):
         """Instantiate Fonz and save authentication details and branch."""
         if url[-1] == '/':
             self.url = '{}:{}/api/{}/'.format(url[:-1], port, api)
@@ -22,6 +23,7 @@ class Fonz:
 
         self.client_id = client_id
         self.client_secret = client_secret
+        self.model = model
         self.branch = branch
         self.project = project
         self.client = None
@@ -75,11 +77,12 @@ class Fonz:
 
         for model in models.json():
             if model['project_name'] == self.project:
-                for explore in model['explores']:
-                    explores.append({
-                        'model': model['name'],
-                        'explore': explore['name']
-                        })
+                if model['name'] == self.model or self.model is None:
+                    for explore in model['explores']:
+                        explores.append({
+                            'model': model['name'],
+                            'explore': explore['name']
+                            })
 
         return explores
 

--- a/fonz/connection.py
+++ b/fonz/connection.py
@@ -1,7 +1,8 @@
 from typing import Sequence, List, Dict, Any, Optional
 from fonz.utils import compose_url
 from fonz.logger import GLOBAL_LOGGER as logger
-from fonz.printer import print_start, print_fail, print_pass
+from fonz.printer import (
+    print_start, print_fail, print_pass, print_error, print_stats)
 import requests
 import sys
 
@@ -30,7 +31,7 @@ class Fonz:
     def connect(self) -> None:
         """Authenticate, start a dev session, check out specified branch."""
 
-        logger.info('Authenticating Looker credentials.')
+        logger.info('Authenticating Looker credentials. \n')
 
         login = requests.post(
             url=compose_url(self.url, 'login'),
@@ -166,9 +167,21 @@ class Fonz:
 
         return explores
 
-    def print_results(self, explores: List[JsonDict]) -> bool:
+    def handle_errors(self, explores: List[JsonDict]) -> None:
         """Prints errors and returns whether errors were present"""
-        pass
+
+        total = len(explores)
+        errors = 0
+
+        for explore in explores:
+            if explore['failed']:
+                errors += 1
+                print_error(explore)
+
+        print_stats(errors, total)
+
+        if errors > 0:
+            sys.exit(1)
 
     def validate_content(self) -> JsonDict:
         """Validate all content and return any JSON errors."""

--- a/fonz/connection.py
+++ b/fonz/connection.py
@@ -2,7 +2,8 @@ from typing import Sequence, List, Dict, Any, Optional
 from fonz.utils import compose_url
 from fonz.logger import GLOBAL_LOGGER as logger
 from fonz.printer import (
-    print_start, print_fail, print_pass, print_error, print_stats)
+    print_start, print_fail, print_pass, print_error,
+    print_stats, print_progress)
 import requests
 import sys
 
@@ -105,9 +106,15 @@ class Fonz:
 
     def get_dimensions(self, explores: List[JsonDict]) -> List[JsonDict]:
         """Finds the dimensions for all explores"""
-        for explore in explores:
-            explore['dimensions'] = self.get_explore_dimensions(explore)
 
+        total = len(explores)
+        print_progress(0, total, prefix='Finding Dimensions')
+
+        for index, explore in enumerate(explores):
+            explore['dimensions'] = self.get_explore_dimensions(explore)
+            print_progress(index+1, total, prefix='Finding Dimensions')
+
+        logger.info('Collected dimensions for each explores.')
         return explores
 
     def create_query(self, explore: JsonDict) -> int:
@@ -152,6 +159,8 @@ class Fonz:
 
             query_id = self.create_query(explore)
             query_result = self.run_query(query_id)
+
+            logger.debug(query_result)
 
             if 'looker_error' in query_result[0]:
                 logger.debug('Error in explore {}: {}'.format(

--- a/fonz/connection.py
+++ b/fonz/connection.py
@@ -103,7 +103,8 @@ class Fonz:
         dimensions = []
 
         for dimension in lookml_explore.json()['fields']['dimensions']:
-            dimensions.append(dimension['name'])
+            if 'fonz_ignore' not in dimension['sql']:
+                dimensions.append(dimension['name'])
 
         return dimensions
 

--- a/fonz/connection.py
+++ b/fonz/connection.py
@@ -30,13 +30,12 @@ class Fonz:
         self.base_url = "{}:{}/api/{}/".format(url.rstrip("/"), port, api)
         self.client_id = client_id
         self.client_secret = client_secret
-        self.model = model
         self.branch = branch
         self.project = project
         self.client = None
         self.session = requests.Session()
 
-        logger.debug("Instantiated Fonz object for url: {}".format(url))
+        logger.debug("Instantiated Fonz object for url: {}".format(self.base_url))
 
     def connect(self) -> None:
         """Authenticate, start a dev session, check out specified branch."""
@@ -116,7 +115,7 @@ class Fonz:
         dimensions = []
 
         for dimension in response.json()["fields"]["dimensions"]:
-            if "fonz_ignore" not in dimension["sql"]:
+            if "fonz: ignore" not in dimension["sql"]:
                 dimensions.append(dimension["name"])
 
         return dimensions
@@ -172,9 +171,8 @@ class Fonz:
 
         logger.debug("Getting SQL for query {}".format(query_id))
 
-        query = requests.get(
-            url=compose_url(self.url, "queries", query_id, "run", "sql"),
-            headers=self.headers,
+        query = self.session.get(
+            url=compose_url(self.base_url, path=["queries", query_id, "run", "sql"])
         )
 
         return query.text

--- a/fonz/logger.py
+++ b/fonz/logger.py
@@ -1,19 +1,19 @@
 import logging
 import os
 
-if not os.path.exists('logs/'):
-    os.mkdir('logs')
+if not os.path.exists("logs/"):
+    os.mkdir("logs")
 
-logger = logging.getLogger('Fonz')
+logger = logging.getLogger("Fonz")
 logger.setLevel(logging.DEBUG)
 
-fh = logging.FileHandler('./logs/logs.txt')
+fh = logging.FileHandler("./logs/logs.txt")
 fh.setLevel(logging.DEBUG)
 
 ch = logging.StreamHandler()
 ch.setLevel(logging.INFO)
 
-formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 fh.setFormatter(formatter)
 
 logger.addHandler(fh)

--- a/fonz/logger.py
+++ b/fonz/logger.py
@@ -1,0 +1,18 @@
+import logging
+
+logger = logging.getLogger('Fonz')
+logger.setLevel(logging.DEBUG)
+
+fh = logging.FileHandler('./logs.txt')
+fh.setLevel(logging.DEBUG)
+
+ch = logging.StreamHandler()
+ch.setLevel(logging.INFO)
+
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+fh.setFormatter(formatter)
+
+logger.addHandler(fh)
+logger.addHandler(ch)
+
+GLOBAL_LOGGER = logger

--- a/fonz/logger.py
+++ b/fonz/logger.py
@@ -1,9 +1,13 @@
 import logging
+import os
+
+if not os.path.exists('logs/'):
+    os.mkdir('logs')
 
 logger = logging.getLogger('Fonz')
 logger.setLevel(logging.DEBUG)
 
-fh = logging.FileHandler('./logs.txt')
+fh = logging.FileHandler('./logs/logs.txt')
 fh.setLevel(logging.DEBUG)
 
 ch = logging.StreamHandler()

--- a/fonz/printer.py
+++ b/fonz/printer.py
@@ -34,61 +34,62 @@ def yellow(text):
 
 
 def print_fancy_line(msg: str, status: str, index: int, total: int) -> None:
-    progress = '{} of {} '.format(index, total)
+    progress = "{} of {} ".format(index, total)
     prefix = "{timestamp} | {progress}{message}".format(
-        timestamp=get_timestamp(),
-        progress=progress,
-        message=msg)
+        timestamp=get_timestamp(), progress=progress, message=msg
+    )
 
     justified = prefix.ljust(PRINTER_WIDTH, ".")
 
     status_txt = status
 
-    output = "{justified} [{status}]".format(
-        justified=justified, status=status_txt)
+    output = "{justified} [{status}]".format(justified=justified, status=status_txt)
 
     logger.info(output)
 
 
 def print_start(explore: JsonDict, index: int, total: int) -> None:
-    msg = "CHECKING explore: {}".format(explore['explore'])
-    print_fancy_line(msg, 'START', index, total)
+    msg = "CHECKING explore: {}".format(explore["explore"])
+    print_fancy_line(msg, "START", index, total)
 
 
 def print_pass(explore: JsonDict, index: int, total: int) -> None:
-    msg = "PASSED explore: {}".format(explore['explore'])
-    print_fancy_line(msg, green('PASS'), index, total)
+    msg = "PASSED explore: {}".format(explore["explore"])
+    print_fancy_line(msg, green("PASS"), index, total)
 
 
 def print_fail(explore: JsonDict, index: int, total: int) -> None:
-    msg = "FAILED explore: {}".format(explore['explore'])
-    print_fancy_line(msg, red('FAIL'), index, total)
+    msg = "FAILED explore: {}".format(explore["explore"])
+    print_fancy_line(msg, red("FAIL"), index, total)
 
 
 def print_error(explore: JsonDict):
-    error_msg = ("\nFailure in explore {}: \"{}\"".format(
-        explore['explore'], explore['error']))
+    error_msg = '\nFailure in explore {}: "{}"'.format(
+        explore["explore"], explore["error"]
+    )
 
-    url_msg = ("More details at {}".format(explore['query_url']))
+    url_msg = "More details at {}".format(explore["query_url"])
 
     logger.info(yellow(error_msg))
     logger.info(yellow(url_msg))
 
 
 def print_stats(errors: int, total: int) -> None:
-    stats = {
-        'error': errors,
-        'pass': total - errors,
-        'total': total,
-    }
+    stats = {"error": errors, "pass": total - errors, "total": total}
 
     stats_line = "\nDone. PASS={pass} ERROR={error} TOTAL={total}"
     logger.info(stats_line.format(**stats))
 
 
 def print_progress(
-        iteration: int, total: int, prefix: str = '', suffix: str = '',
-        decimals: int = 1, length: int = 80, fill: str = '█'):
+    iteration: int,
+    total: int,
+    prefix: str = "",
+    suffix: str = "",
+    decimals: int = 1,
+    length: int = 80,
+    fill: str = "█",
+):
     """
     Call in a loop to create terminal progress bar
     @params:
@@ -100,12 +101,11 @@ def print_progress(
         length      - Optional  : character length of bar (Int)
         fill        - Optional  : bar fill character (Str)
     """
-    percent = ("{0:." + str(decimals) + "f}").format(
-        100 * (iteration / float(total)))
+    percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
 
     filledLength = int(length * iteration // total)
-    bar = fill * filledLength + '-' * (length - filledLength)
-    print('\r%s |%s| %s%% %s' % (prefix, bar, percent, suffix), end='\r')
+    bar = fill * filledLength + "-" * (length - filledLength)
+    print("\r%s |%s| %s%% %s" % (prefix, bar, percent, suffix), end="\r")
     # Print New Line on Complete
     if iteration == total:
-        print('\n')
+        print("\n")

--- a/fonz/printer.py
+++ b/fonz/printer.py
@@ -1,0 +1,61 @@
+from typing import Dict, Any
+from fonz.logger import GLOBAL_LOGGER as logger
+import colorama  # type: ignore
+import time
+
+JsonDict = Dict[str, Any]
+
+COLOR_FG_RED = colorama.Fore.RED
+COLOR_FG_GREEN = colorama.Fore.GREEN
+COLOR_FG_YELLOW = colorama.Fore.YELLOW
+COLOR_RESET_ALL = colorama.Style.RESET_ALL
+
+PRINTER_WIDTH = 80
+
+
+def get_timestamp() -> str:
+    return time.strftime("%H:%M:%S")
+
+
+def color(text: str, color_code: str) -> str:
+    return "{}{}{}".format(color_code, text, COLOR_RESET_ALL)
+
+
+def green(text):
+    return color(text, COLOR_FG_GREEN)
+
+
+def red(text):
+    return color(text, COLOR_FG_RED)
+
+
+def print_fancy_line(msg: str, status: str, index: int, total: int) -> None:
+    progress = '{} of {} '.format(index, total)
+    prefix = "{timestamp} | {progress}{message}".format(
+        timestamp=get_timestamp(),
+        progress=progress,
+        message=msg)
+
+    justified = prefix.ljust(PRINTER_WIDTH, ".")
+
+    status_txt = status
+
+    output = "{justified} [{status}]".format(
+        justified=justified, status=status_txt)
+
+    logger.info(output)
+
+
+def print_start(explore: JsonDict, index: int, total: int) -> None:
+    msg = "CHECKING explore: {}".format(explore['explore'])
+    print_fancy_line(msg, 'START', index, total)
+
+
+def print_pass(explore: JsonDict, index: int, total: int) -> None:
+    msg = "PASSED explore: {}".format(explore['explore'])
+    print_fancy_line(msg, green('PASS'), index, total)
+
+
+def print_fail(explore: JsonDict, index: int, total: int) -> None:
+    msg = "FAILED explore: {}".format(explore['explore'])
+    print_fancy_line(msg, red('FAIL'), index, total)

--- a/fonz/printer.py
+++ b/fonz/printer.py
@@ -29,6 +29,10 @@ def red(text):
     return color(text, COLOR_FG_RED)
 
 
+def yellow(text):
+    return color(text, COLOR_FG_YELLOW)
+
+
 def print_fancy_line(msg: str, status: str, index: int, total: int) -> None:
     progress = '{} of {} '.format(index, total)
     prefix = "{timestamp} | {progress}{message}".format(
@@ -59,3 +63,21 @@ def print_pass(explore: JsonDict, index: int, total: int) -> None:
 def print_fail(explore: JsonDict, index: int, total: int) -> None:
     msg = "FAILED explore: {}".format(explore['explore'])
     print_fancy_line(msg, red('FAIL'), index, total)
+
+
+def print_error(explore: JsonDict):
+    msg = ("\nFailure in explore {}: \"{}\"".format(
+        explore['explore'], explore['error']))
+
+    logger.info(yellow(msg))
+
+
+def print_stats(errors: int, total: int) -> None:
+    stats = {
+        'error': errors,
+        'pass': total - errors,
+        'total': total,
+    }
+
+    stats_line = "\nDone. PASS={pass} ERROR={error} TOTAL={total}"
+    logger.info(stats_line.format(**stats))

--- a/fonz/printer.py
+++ b/fonz/printer.py
@@ -66,10 +66,13 @@ def print_fail(explore: JsonDict, index: int, total: int) -> None:
 
 
 def print_error(explore: JsonDict):
-    msg = ("\nFailure in explore {}: \"{}\"".format(
+    error_msg = ("\nFailure in explore {}: \"{}\"".format(
         explore['explore'], explore['error']))
 
-    logger.info(yellow(msg))
+    url_msg = ("More details at {}".format(explore['query_url']))
+
+    logger.info(yellow(error_msg))
+    logger.info(yellow(url_msg))
 
 
 def print_stats(errors: int, total: int) -> None:

--- a/fonz/printer.py
+++ b/fonz/printer.py
@@ -81,3 +81,28 @@ def print_stats(errors: int, total: int) -> None:
 
     stats_line = "\nDone. PASS={pass} ERROR={error} TOTAL={total}"
     logger.info(stats_line.format(**stats))
+
+
+def print_progress(
+        iteration: int, total: int, prefix: str = '', suffix: str = '',
+        decimals: int = 1, length: int = 80, fill: str = '█'):
+    """
+    Call in a loop to create terminal progress bar
+    @params:
+        iteration   - Required  : current iteration (Int)
+        total       - Required  : total iterations (Int)
+        prefix      - Optional  : prefix string (Str)
+        suffix      - Optional  : suffix string (Str)
+        decimals    - Optional  : positive number of decimals in percentage
+        length      - Optional  : character length of bar (Int)
+        fill        - Optional  : bar fill character (Str)
+    """
+    percent = ("{0:." + str(decimals) + "f}").format(
+        100 * (iteration / float(total)))
+
+    filledLength = int(length * iteration // total)
+    bar = fill * filledLength + '-' * (length - filledLength)
+    print('\r%s |%s| %s%% %s' % (prefix, bar, percent, suffix), end='\r')
+    # Print New Line on Complete
+    if iteration == total:
+        print('\n')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pycodestyle==2.5.0
 pytest==4.5.0
 pytest-cov==2.7.1
 setuptools==40.8.0
+colorama==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
         'mypy',
         'pycodestyle',
         'pytest-cov',
-        'coverage'
+        'coverage',
+        'colorama'
     ],
     entry_points='''
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,17 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'Click',
-        'requests',
-        'pytest',
+        "Click",
+        "requests",
+        "pytest",
         "PyYAML",
-        'requests-mock',
-        'coverage',
-        'mypy',
-        'pycodestyle',
-        'pytest-cov',
-        'coverage',
-        'colorama'
+        "requests-mock",
+        "coverage",
+        "mypy",
+        "pycodestyle",
+        "pytest-cov",
+        "coverage",
+        "colorama",
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
This builds on #5, which has yet to be merged, but it was going to be difficult to write on it's own. I wanted to split it out into its own PR though. 

This PR achieves two things:

* improves how we use logging in Fonz (set up new file `logger.py`)
* sets up nice printing for the run

For the printing, it looks VERY dbt for the moment. 

For a passing run: 
<img width="650" alt="Screenshot 2019-05-27 at 13 17 18" src="https://user-images.githubusercontent.com/10001014/58419399-6c255300-8082-11e9-876e-d0a367251c3f.png">

For a failing run: 
<img width="718" alt="Screenshot 2019-05-27 at 13 17 31" src="https://user-images.githubusercontent.com/10001014/58419398-6b8cbc80-8082-11e9-993f-e15d977b9c6a.png">

If a run fails, I have set it to finish with exit code 1, which should pass an error to CI systems.
