### PR TITLE
CLI upgrades and testing

### DIFF
--- a/fonz/cli.py
+++ b/fonz/cli.py
@@ -9,8 +9,8 @@ def cli():
 
 @click.command()
 @click.argument("url", envvar="LOOKER_BASE_URL")
-@click.argument("client_id", envvar="LOOKER_CLIENT_ID")
-@click.argument("client_secret", envvar="LOOKER_CLIENT_SECRET")
+@click.option("--client-id", required=True, envvar="LOOKER_CLIENT_ID")
+@click.option("--client-secret", required=True, envvar="LOOKER_CLIENT_SECRET")
 @click.option("--port", default=19999)
 @click.option("--api", default="3.0")
 def connect(url, client_id, client_secret, port, api):

--- a/fonz/cli.py
+++ b/fonz/cli.py
@@ -28,9 +28,9 @@ def cli():
 @click.option("--client-secret", envvar="LOOKER_CLIENT_SECRET")
 @click.option("--config-file")
 @click.option("--port", default=19999)
-@click.option("--api", default="3.0")
-def connect(base_url, client_id, client_secret, config_file, port, api):
-    client = Fonz(base_url, client_id, client_secret, port, api)
+@click.option("--api-version", default="3.0")
+def connect(base_url, client_id, client_secret, config_file, port, api_version):
+    client = Fonz(base_url, client_id, client_secret, port, api_version)
     client.connect()
 
 
@@ -42,9 +42,13 @@ def connect(base_url, client_id, client_secret, config_file, port, api):
 @click.option("--client-secret", envvar="LOOKER_CLIENT_SECRET")
 @click.option("--config-file")
 @click.option("--port", default=19999)
-@click.option("--api", default="3.0")
-def sql(project, branch, base_url, client_id, client_secret, config_file, port, api):
-    client = Fonz(base_url, client_id, client_secret, port, api, project, branch)
+@click.option("--api-version", default="3.0")
+def sql(
+    project, branch, base_url, client_id, client_secret, config_file, port, api_version
+):
+    client = Fonz(
+        base_url, client_id, client_secret, port, api_version, project, branch
+    )
     client.connect()
     client.update_session()
     explores = client.get_explores()

--- a/fonz/cli.py
+++ b/fonz/cli.py
@@ -34,16 +34,17 @@ def connect(base_url, client_id, client_secret, config_file, port, api):
     client.connect()
 
 
-@click.command()
-@click.argument("project")
-@click.argument("branch")
-@click.argument("url", envvar="LOOKER_BASE_URL")
-@click.argument("client_id", envvar="LOOKER_CLIENT_ID")
-@click.argument("client_secret", envvar="LOOKER_CLIENT_SECRET")
+@click.command(cls=CommandWithConfig)
+@click.option("--project", envvar="LOOKER_PROJECT")
+@click.option("--branch", envvar="LOOKER_GIT_BRANCH")
+@click.option("--base-url", envvar="LOOKER_BASE_URL")
+@click.option("--client-id", envvar="LOOKER_CLIENT_ID")
+@click.option("--client-secret", envvar="LOOKER_CLIENT_SECRET")
+@click.option("--config-file")
 @click.option("--port", default=19999)
 @click.option("--api", default="3.0")
-def sql(url, client_id, client_secret, port, api, project, branch):
-    client = Fonz(url, client_id, client_secret, port, api, project, branch)
+def sql(project, branch, base_url, client_id, client_secret, config_file, port, api):
+    client = Fonz(base_url, client_id, client_secret, port, api, project, branch)
     client.connect()
     client.update_session()
     explores = client.get_explores()

--- a/fonz/tests/constants.py
+++ b/fonz/tests/constants.py
@@ -1,0 +1,1 @@
+TEST_BASE_URL = "https://test.looker.com"

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -23,7 +23,7 @@ class TestConnect(object):
         assert result.exit_code == 0
 
     def test_no_arguments_exits_with_nonzero_code(self):
-        result = self.runner.invoke(connect, catch_exceptions=False)
+        result = self.runner.invoke(connect)
         assert result.exit_code != 0
 
     @patch("fonz.cli.Fonz", autospec=True)

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
@@ -18,7 +19,7 @@ class TestConnect(object):
         assert result.exit_code == 0
 
     def test_no_arguments_exits_with_nonzero_code(self):
-        result = self.runner.invoke(connect, [])
+        result = self.runner.invoke(connect)
         assert result.exit_code != 0
 
     @patch("fonz.connection.Fonz.connect")
@@ -35,8 +36,18 @@ class TestConnect(object):
         )
         assert result.exit_code == 0
 
-    def test_with_env_vars_only(self):
-        pass
+    @patch("fonz.connection.Fonz.connect")
+    @patch.dict(
+        os.environ,
+        {
+            "LOOKER_BASE_URL": "https://test.looker.com",
+            "LOOKER_CLIENT_ID": "FAKE_CLIENT_ID",
+            "LOOKER_CLIENT_SECRET": "FAKE_CLIENT_SECRET",
+        },
+    )
+    def test_with_env_vars_only(self, mock_connect):
+        result = self.runner.invoke(connect)
+        assert result.exit_code == 0
 
     def test_with_config_file_only(self):
         pass

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 from fonz.cli import connect
@@ -20,7 +21,8 @@ class TestConnect(object):
         result = self.runner.invoke(connect, [])
         assert result.exit_code != 0
 
-    def test_with_command_line_args_only(self):
+    @patch("fonz.connection.Fonz.connect")
+    def test_with_command_line_args_only(self, mock_connect):
         result = self.runner.invoke(
             connect,
             [

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -78,7 +78,7 @@ class TestConnect(object):
                 yaml.dump(config, file)
         result = self.runner.invoke(
             connect,
-            [TEST_BASE_URL, "--config-file", "config.yml"],
+            ["--config-file", "config.yml"],
             standalone_mode=False,
             catch_exceptions=False,
         )

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -1,7 +1,8 @@
 import os
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 import pytest
 from click.testing import CliRunner
+from fonz.tests.constants import TEST_BASE_URL
 from fonz.cli import connect
 import logging
 
@@ -22,31 +23,39 @@ class TestConnect(object):
         result = self.runner.invoke(connect)
         assert result.exit_code != 0
 
-    @patch("fonz.connection.Fonz.connect")
-    def test_with_command_line_args_only(self, mock_connect):
+    @patch("fonz.cli.Fonz", autospec=True)
+    def test_with_command_line_args_only(self, mock_client):
         result = self.runner.invoke(
             connect,
             [
-                "https://test.looker.com",
+                TEST_BASE_URL,
                 "--client-id",
                 "FAKE_CLIENT_ID",
                 "--client-secret",
                 "FAKE_CLIENT_SECRET",
             ],
         )
+        mock_client.assert_called_once_with(
+            TEST_BASE_URL, "FAKE_CLIENT_ID", "FAKE_CLIENT_SECRET", 19999, "3.0"
+        )
+        mock_client.return_value.connect.assert_called_once()
         assert result.exit_code == 0
 
-    @patch("fonz.connection.Fonz.connect")
+    @patch("fonz.cli.Fonz", autospec=True)
     @patch.dict(
         os.environ,
         {
-            "LOOKER_BASE_URL": "https://test.looker.com",
+            "LOOKER_BASE_URL": TEST_BASE_URL,
             "LOOKER_CLIENT_ID": "FAKE_CLIENT_ID",
             "LOOKER_CLIENT_SECRET": "FAKE_CLIENT_SECRET",
         },
     )
-    def test_with_env_vars_only(self, mock_connect):
+    def test_with_env_vars_only(self, mock_client):
         result = self.runner.invoke(connect)
+        mock_client.assert_called_once_with(
+            TEST_BASE_URL, "FAKE_CLIENT_ID", "FAKE_CLIENT_SECRET", 19999, "3.0"
+        )
+        mock_client.return_value.connect.assert_called_once()
         assert result.exit_code == 0
 
     def test_with_config_file_only(self):

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -88,5 +88,21 @@ class TestConnect(object):
         mock_client.return_value.connect.assert_called_once()
         assert result.exit_code == 0
 
-    def test_with_config_file_args_and_env_vars(self):
-        pass
+    @patch("fonz.cli.Fonz", autospec=True)
+    @patch.dict(os.environ, {"LOOKER_CLIENT_SECRET": "FAKE_CLIENT_SECRET"})
+    def test_with_config_file_args_and_env_vars(self, mock_client):
+        with self.runner.isolated_filesystem():
+            with open("config.yml", "w") as file:
+                config = {"client_id": "FAKE_CLIENT_ID"}
+                yaml.dump(config, file)
+            result = self.runner.invoke(
+                connect,
+                ["--base-url", TEST_BASE_URL, "--config-file", "config.yml"],
+                standalone_mode=False,
+                catch_exceptions=False,
+            )
+        mock_client.assert_called_once_with(
+            TEST_BASE_URL, "FAKE_CLIENT_ID", "FAKE_CLIENT_SECRET", 19999, "3.0"
+        )
+        mock_client.return_value.connect.assert_called_once()
+        assert result.exit_code == 0

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -31,6 +31,7 @@ class TestConnect(object):
         result = self.runner.invoke(
             connect,
             [
+                "--base-url",
                 TEST_BASE_URL,
                 "--client-id",
                 "FAKE_CLIENT_ID",
@@ -77,7 +78,7 @@ class TestConnect(object):
                 yaml.dump(config, file)
         result = self.runner.invoke(
             connect,
-            ["--config-file", "config.yml"],
+            [TEST_BASE_URL, "--config-file", "config.yml"],
             standalone_mode=False,
             catch_exceptions=False,
         )

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -4,7 +4,7 @@ import yaml
 import pytest
 from click.testing import CliRunner
 from fonz.tests.constants import TEST_BASE_URL
-from fonz.cli import connect
+from fonz.cli import connect, sql
 import logging
 
 
@@ -132,3 +132,16 @@ class TestConnect(object):
         )
         mock_client.return_value.connect.assert_called_once()
         assert result.exit_code == 0
+
+
+@pytest.mark.usefixtures("runner")
+class TestSql(object):
+    def test_help(self):
+        result = self.runner.invoke(
+            sql, ["--help"], standalone_mode=False, catch_exceptions=False
+        )
+        assert result.exit_code == 0
+
+    def test_no_arguments_exits_with_nonzero_code(self):
+        result = self.runner.invoke(sql)
+        assert result.exit_code != 0

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -76,12 +76,12 @@ class TestConnect(object):
                     "client_secret": "FAKE_CLIENT_SECRET",
                 }
                 yaml.dump(config, file)
-        result = self.runner.invoke(
-            connect,
-            ["--config-file", "config.yml"],
-            standalone_mode=False,
-            catch_exceptions=False,
-        )
+            result = self.runner.invoke(
+                connect,
+                ["--config-file", "config.yml"],
+                standalone_mode=False,
+                catch_exceptions=False,
+            )
         mock_client.assert_called_once_with(
             TEST_BASE_URL, "FAKE_CLIENT_ID", "FAKE_CLIENT_SECRET", 19999, "3.0"
         )

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -176,3 +176,134 @@ class TestSql(object):
         )
         mock_client.return_value.connect.assert_called_once()
         assert result.exit_code == 0
+
+    @patch("fonz.cli.Fonz", autospec=True)
+    @patch.dict(
+        os.environ,
+        {
+            "LOOKER_BASE_URL": TEST_BASE_URL,
+            "LOOKER_CLIENT_ID": "FAKE_CLIENT_ID",
+            "LOOKER_CLIENT_SECRET": "FAKE_CLIENT_SECRET",
+            "LOOKER_PROJECT": "FAKE_PROJECT",
+            "LOOKER_GIT_BRANCH": "FAKE_BRANCH",
+        },
+    )
+    def test_with_env_vars_only(self, mock_client):
+        result = self.runner.invoke(sql, standalone_mode=False, catch_exceptions=False)
+        mock_client.assert_called_once_with(
+            TEST_BASE_URL,
+            "FAKE_CLIENT_ID",
+            "FAKE_CLIENT_SECRET",
+            19999,
+            "3.0",
+            "FAKE_PROJECT",
+            "FAKE_BRANCH",
+        )
+        mock_client.return_value.connect.assert_called_once()
+        assert result.exit_code == 0
+
+    @patch("fonz.cli.Fonz", autospec=True)
+    def test_with_config_file_only(self, mock_client):
+        with self.runner.isolated_filesystem():
+            with open("config.yml", "w") as file:
+                config = {
+                    "base_url": TEST_BASE_URL,
+                    "client_id": "FAKE_CLIENT_ID",
+                    "client_secret": "FAKE_CLIENT_SECRET",
+                    "project": "FAKE_PROJECT",
+                    "branch": "FAKE_BRANCH",
+                }
+                yaml.dump(config, file)
+            result = self.runner.invoke(
+                sql,
+                ["--config-file", "config.yml"],
+                standalone_mode=False,
+                catch_exceptions=False,
+            )
+        mock_client.assert_called_once_with(
+            TEST_BASE_URL,
+            "FAKE_CLIENT_ID",
+            "FAKE_CLIENT_SECRET",
+            19999,
+            "3.0",
+            "FAKE_PROJECT",
+            "FAKE_BRANCH",
+        )
+        mock_client.return_value.connect.assert_called_once()
+        assert result.exit_code == 0
+
+    @patch("fonz.cli.Fonz", autospec=True)
+    @patch.dict(
+        os.environ,
+        {
+            "LOOKER_CLIENT_SECRET": "FAKE_CLIENT_SECRET",
+            "LOOKER_GIT_BRANCH": "FAKE_BRANCH",
+        },
+    )
+    def test_with_config_file_args_and_env_vars(self, mock_client):
+        with self.runner.isolated_filesystem():
+            with open("config.yml", "w") as file:
+                config = {"client_id": "FAKE_CLIENT_ID", "project": "FAKE_PROJECT"}
+                yaml.dump(config, file)
+            result = self.runner.invoke(
+                sql,
+                ["--base-url", TEST_BASE_URL, "--config-file", "config.yml"],
+                standalone_mode=False,
+                catch_exceptions=False,
+            )
+        mock_client.assert_called_once_with(
+            TEST_BASE_URL,
+            "FAKE_CLIENT_ID",
+            "FAKE_CLIENT_SECRET",
+            19999,
+            "3.0",
+            "FAKE_PROJECT",
+            "FAKE_BRANCH",
+        )
+        mock_client.return_value.connect.assert_called_once()
+        assert result.exit_code == 0
+
+    @patch("fonz.cli.Fonz", autospec=True)
+    @patch.dict(
+        os.environ,
+        {
+            "LOOKER_BASE_URL": "URL_ENV_VAR",
+            "LOOKER_CLIENT_ID": "CLIENT_ID_ENV_VAR",
+            "LOOKER_PROJECT": "PROJECT_ENV_VAR",
+        },
+    )
+    def test_cli_supersedes_env_var_which_supersedes_config_file(self, mock_client):
+        with self.runner.isolated_filesystem():
+            with open("config.yml", "w") as file:
+                config = {
+                    "base_url": "URL_CONFIG_FILE",
+                    "client_id": "CLIENT_ID_CONFIG_FILE",
+                    "client_secret": "CLIENT_SECRET_CONFIG_FILE",
+                    "branch": "BRANCH_CONFIG_FILE",
+                    "project": "PROJECT_CONFIG_FILE",
+                }
+                yaml.dump(config, file)
+            result = self.runner.invoke(
+                sql,
+                [
+                    "--base-url",
+                    "URL_CLI",
+                    "--branch",
+                    "BRANCH_CLI",
+                    "--config-file",
+                    "config.yml",
+                ],
+                standalone_mode=False,
+                catch_exceptions=False,
+            )
+        mock_client.assert_called_once_with(
+            "URL_CLI",
+            "CLIENT_ID_ENV_VAR",
+            "CLIENT_SECRET_CONFIG_FILE",
+            19999,
+            "3.0",
+            "PROJECT_ENV_VAR",
+            "BRANCH_CLI",
+        )
+        mock_client.return_value.connect.assert_called_once()
+        assert result.exit_code == 0

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -1,0 +1,43 @@
+import pytest
+from click.testing import CliRunner
+from fonz.cli import connect
+import logging
+
+
+@pytest.fixture(scope="class")
+def runner(request):
+    """Click's CLI runner to invoke commands as command line scripts."""
+    request.cls.runner = CliRunner()
+
+
+@pytest.mark.usefixtures("runner")
+class TestConnect(object):
+    def test_help(self):
+        result = self.runner.invoke(connect, ["--help"])
+        assert result.exit_code == 0
+
+    def test_no_arguments_exits_with_nonzero_code(self):
+        result = self.runner.invoke(connect, [])
+        assert result.exit_code != 0
+
+    def test_with_command_line_args_only(self):
+        result = self.runner.invoke(
+            connect,
+            [
+                "https://test.looker.com",
+                "--client-id",
+                "FAKE_CLIENT_ID",
+                "--client-secret",
+                "FAKE_CLIENT_SECRET",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_with_env_vars_only(self):
+        pass
+
+    def test_with_config_file_only(self):
+        pass
+
+    def test_with_config_file_args_and_env_vars(self):
+        pass

--- a/fonz/tests/test_cli.py
+++ b/fonz/tests/test_cli.py
@@ -145,3 +145,34 @@ class TestSql(object):
     def test_no_arguments_exits_with_nonzero_code(self):
         result = self.runner.invoke(sql)
         assert result.exit_code != 0
+
+    @patch("fonz.cli.Fonz", autospec=True)
+    def test_with_command_line_args_only(self, mock_client):
+        result = self.runner.invoke(
+            sql,
+            [
+                "--base-url",
+                TEST_BASE_URL,
+                "--client-id",
+                "FAKE_CLIENT_ID",
+                "--client-secret",
+                "FAKE_CLIENT_SECRET",
+                "--project",
+                "FAKE_PROJECT",
+                "--branch",
+                "FAKE_BRANCH",
+            ],
+            standalone_mode=False,
+            catch_exceptions=False,
+        )
+        mock_client.assert_called_once_with(
+            TEST_BASE_URL,
+            "FAKE_CLIENT_ID",
+            "FAKE_CLIENT_SECRET",
+            19999,
+            "3.0",
+            "FAKE_PROJECT",
+            "FAKE_BRANCH",
+        )
+        mock_client.return_value.connect.assert_called_once()
+        assert result.exit_code == 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mypy==0.700
 pytest==4.5.0
 pytest-cov==2.7.1
 setuptools==40.8.0
+PyYAML==5.1

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     install_requires=[
         "Click",
         "requests",
+        "PyYAML",
         "pytest",
         "requests-mock",
         "coverage",


### PR DESCRIPTION
This PR mainly adds testing coverage for `cli.py`. I'm using a few key concepts here:

1. `click` has a small testing library with a class called `CliRunner`. This is used to simulate an actual call from the command line with a list of options and arguments. I've set this up as a pytest fixture which is used by each test class (becomes a class attribute called `runner`).

2. I've mocked the `Fonz` class in a few places so we can test the mock using `assert_called_with` and ensure it's being instantiated correctly.

3. Implemented a hierarchy of `CLI > Environment Variable > Config` for option selection. I know we talked about the config file being a higher priority than environment variables, but it's difficult to set up that way with the way `click` works. Plus, I think it makes sense for env vars to take precedent.

4. I had to override the `click.Command` class's invoke method to allow arguments to be collected from a YAML config file. I mostly lifted this code from a SO post [here](https://stackoverflow.com/questions/46358797/python-click-supply-arguments-and-options-from-a-configuration-file).